### PR TITLE
Bump minimum Ruby version to 2.6.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 /spec/reports/
 /tmp/
 
+# local Ruby versioning
+.ruby-version
+
 # rspec failure tracking
 .rspec_status
 

--- a/prawn-dev.gemspec
+++ b/prawn-dev.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.summary = 'Shared tools for Prawn projects development'
   spec.homepage = 'https://prawnpdf.org/'
   spec.license = 'MIT'
-  spec.required_ruby_version = '>= 2.5.0'
+  spec.required_ruby_version = '>= 2.6.0'
   spec.required_rubygems_version = '>= 2.0'
 
   spec.cert_chain = ['certs/pointlessone.pem']
@@ -28,9 +28,9 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency('rake', '~> 13.0')
   spec.add_runtime_dependency('rspec', '~> 3.0')
-  spec.add_runtime_dependency('rubocop', '~> 1.8.1')
-  spec.add_runtime_dependency('rubocop-performance', '~> 1.9.2')
-  spec.add_runtime_dependency('rubocop-rspec', '~> 2.1.0')
+  spec.add_runtime_dependency('rubocop', '~> 1.25.1')
+  spec.add_runtime_dependency('rubocop-performance', '~> 1.13.2')
+  spec.add_runtime_dependency('rubocop-rspec', '~> 2.8.0')
   spec.add_runtime_dependency('simplecov', '~> 0.21.2')
   spec.add_runtime_dependency('yard', '~> 0.9.17')
 end

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -3,7 +3,7 @@ require:
   - rubocop-rspec
 
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.6
   Exclude:
     - pkg/**/*
 


### PR DESCRIPTION
This commit bumps the minimum Ruby version to 2.6.0.  It also bumps the rubocop, rubocop-performance, and rubocop-spec gems to the latest, all of which are compatible with 2.6.0 - 3.1.0.

It also adds .ruby-version to .gitignore to make it easier to use/test with different Rubies