### PR TITLE
Fix (or ignore) RuboCop offenses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,2 +1,13 @@
 inherit_from:
   - rubocop.yml
+
+Style/Documentation:
+  Exclude:
+    - lib/rubocop/**/*.rb
+    - lib/prawn/dev/**/*.rb
+
+Style/DocumentationMethod:
+  Exclude:
+    - templates/**/*.rb
+    - lib/rubocop/**/*.rb
+    - lib/prawn/dev/**/*.rb

--- a/lib/prawn/dev/tasks.rb
+++ b/lib/prawn/dev/tasks.rb
@@ -42,7 +42,7 @@ YARD_OPTIONS = [
   '--markup', 'markdown',
   '--markup-provider', 'prawn/dev/yard_markup/document',
   '--use-cache',
-]
+].freeze
 
 YARD::Rake::YardocTask.new do |t|
   t.options = YARD_OPTIONS + t.options

--- a/lib/prawn/dev/tasks.rb
+++ b/lib/prawn/dev/tasks.rb
@@ -19,7 +19,7 @@ end
 file checksum_path => built_gem_path do
   require 'digest/sha2'
   checksum = Digest::SHA512.new.hexdigest(File.read(built_gem_path))
-  Dir.mkdir('checksums') unless Dir.exist?('checksums')
+  Dir.mkdir_p('checksums')
   File.write(checksum_path, checksum)
 end
 

--- a/lib/prawn/dev/tasks.rb
+++ b/lib/prawn/dev/tasks.rb
@@ -10,7 +10,7 @@ package_task = Gem::PackageTask.new(Gem::Specification.load(GEMSPEC))
 package_task.define
 
 built_gem_path = "pkg/#{package_task.package_name}.gem"
-checksum_path = "checksums/#{File.basename built_gem_path}.sha512"
+checksum_path = "checksums/#{File.basename(built_gem_path)}.sha512"
 
 file built_gem_path do
   Rake::Task['package'].invoke
@@ -54,7 +54,7 @@ require 'fileutils'
 def stash_yardopts
   if File.exist?('.yardopts')
     begin
-      original_opts = Shellwords.shellsplit File.read('.yardopts')
+      original_opts = Shellwords.shellsplit(File.read('.yardopts'))
       require('securerandom')
       backup_file = ".yardopts-#{SecureRandom.alphanumeric(16)}.backup"
       FileUtils.move('.yardopts', backup_file)

--- a/lib/prawn/dev/tasks.rb
+++ b/lib/prawn/dev/tasks.rb
@@ -2,7 +2,7 @@
 
 require 'rubygems/package_task'
 
-unless Kernel.const_defined?('GEMSPEC')
+unless Kernel.const_defined?(:GEMSPEC)
   raise StandardError, 'GEMSPEC is not defined'
 end
 

--- a/lib/prawn/dev/yard_markup.rb
+++ b/lib/prawn/dev/yard_markup.rb
@@ -6,7 +6,7 @@ module Prawn
   module Dev
     module YardMarkup
       YARD::Templates::Helpers::MarkupHelper::MARKUP_PROVIDERS[:markdown].push(
-        { lib: :'prawn/dev/yard_markup/document', const: 'Prawn::Dev::YardMarkup::Document' }
+        { lib: :'prawn/dev/yard_markup/document', const: 'Prawn::Dev::YardMarkup::Document' },
       )
       YARD::Templates::Engine.register_template_path(File.expand_path('../../../templates', __dir__))
 

--- a/lib/prawn/dev/yard_markup.rb
+++ b/lib/prawn/dev/yard_markup.rb
@@ -8,9 +8,9 @@ module Prawn
       YARD::Templates::Helpers::MarkupHelper::MARKUP_PROVIDERS[:markdown].push(
         { lib: :'prawn/dev/yard_markup/document', const: 'Prawn::Dev::YardMarkup::Document' }
       )
-      YARD::Templates::Engine.register_template_path File.expand_path('../../../templates', __dir__)
+      YARD::Templates::Engine.register_template_path(File.expand_path('../../../templates', __dir__))
 
-      YARD::Templates::Helpers::HtmlHelper.prepend Prawn::Dev::YardMarkup::CodeHighlight
+      YARD::Templates::Helpers::HtmlHelper.prepend(Prawn::Dev::YardMarkup::CodeHighlight)
     end
   end
 end

--- a/lib/prawn/dev/yard_markup/document.rb
+++ b/lib/prawn/dev/yard_markup/document.rb
@@ -9,6 +9,8 @@ module Prawn
     module YardMarkup
       class CodeFormatter < ::Rouge::Formatter
         def initialize(opts = {})
+          super
+
           @opts = opts
           @formatter =
             if opts[:inline_theme]

--- a/prawn-dev.gemspec
+++ b/prawn-dev.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.metadata['allowed_push_host'] = 'https://rubygems.org'
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = 'https://github.com/prawnpdf/prawn-dev'
+  spec.metadata['rubygems_mfa_required'] = 'true'
 
   spec.files = Dir['lib/**/*.rb', 'rubocop.yml', 'templates/**/*', 'LICENSE.txt']
   spec.require_paths = ['lib']

--- a/prawn-dev.gemspec
+++ b/prawn-dev.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.required_rubygems_version = '>= 2.0'
 
   spec.cert_chain = ['certs/pointlessone.pem']
-  if $PROGRAM_NAME.end_with? 'gem'
+  if $PROGRAM_NAME.end_with?('gem')
     spec.signing_key = File.expand_path('~/.gem/gem-private_key.pem')
   end
 

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -388,7 +388,6 @@ Style/MethodCallWithArgsParentheses:
     - to_not
     - eq
     - be
-    - puts
     - yield
 
 Style/MinMaxComparison:

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -388,6 +388,8 @@ Style/MethodCallWithArgsParentheses:
     - to_not
     - eq
     - be
+    - puts
+    - yield
 
 Style/MinMaxComparison:
   Enabled: true

--- a/templates/default/layout/html/setup.rb
+++ b/templates/default/layout/html/setup.rb
@@ -5,7 +5,7 @@ def stylesheets
 end
 
 def file(basename, allow_inherited = false)
-  puts "  >>  #{basename}"
+  puts("  >>  #{basename}")
   if basename == 'css/syntax-highlight.css'
     return 'body { background: yellow; }'
   end


### PR DESCRIPTION
- Hello from https://status.pointless.one/@pointlessone/113755257216014143.
- I ran `bundle exec rubocop` and fixed the ones it made sense to fix, disabling the ones it didn’t make sense to fix.
- Of particular note is the `RubyGems/RequireMFA` change which may change how you release this gem.
- And I disabled all of the `Style/Documentation`-related new offenses - adding docs is a TODO for someone more familiar with this codebase than me!